### PR TITLE
Replace cms requirement with framework requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 	}],
 	"require": {
         "silverstripe/vendor-plugin": "~1.0 || ~2.0",
-        "silverstripe/cms": "~4.2 || ~5.0",
+        "silverstripe/framework": "~4.2 || ~5.0",
         "fromholdio/silverstripe-gridfield-limiter": "^1.0.0 || ^2.0.0",
         "stevie-mayhew/hasoneedit": "^2.3.0",
         "symbiote/silverstripe-gridfieldextensions": "^3.0.0 || ^4.0.0"


### PR DESCRIPTION
It seems that in the SS5 update the `silverstripe/framework` requirement was replaced with `silverstripe/cms` though some users may want to use this module without the CMS module.